### PR TITLE
Format validator

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -17,6 +17,7 @@ var validatorMap = map[string]reflect.Type{
 	"maxLength": reflect.TypeOf(maxLength(0)),
 	"minLength": reflect.TypeOf(minLength(0)),
 	"pattern":   reflect.TypeOf(pattern{}),
+	"format":    reflect.TypeOf(format("")),
 
 	// Arrays
 	"maxItems": reflect.TypeOf(maxItems(0)),


### PR DESCRIPTION
All tests concerning the format property pass. I'm not sure about a few implementation details though:
1. The regular expressions shouldn't compile on every function call. I'm not sure where to put them though. In the init function?
2. Parsing the mail address with the built-in module might be overkill. According to the spec, pretty much everything containing the @-sign is valid. Maybe we should just check for that.
3. ipv6 accepts ipv4 addresses as well, since they can be converted. Is this important? The regex matching ipv6 addresses is pretty [monstrous](http://forums.intermapper.com/viewtopic.php?t=452).
4. If we can find a different solution for ipv6 addresses, we wouldn't need to import the net module. ipv4 can be checked easily without it.
