### PR TITLE
Fix items validator.

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -350,16 +350,12 @@ func (i *items) SetSchema(v map[string]json.RawMessage) error {
 }
 
 func (i *items) UnmarshalJSON(b []byte) error {
-	err1 := json.Unmarshal(b, &i.schema)
-	if err1 != nil {
-		i.schema = nil
+	if err := json.Unmarshal(b, &i.schema); err == nil {
+		return nil
 	}
-	err2 := json.Unmarshal(b, &i.schemaSlice)
-	if err2 != nil {
-		i.schemaSlice = nil
-	}
-	if err1 != nil && err2 != nil {
-		return err2
+	i.schema = nil
+	if err := json.Unmarshal(b, &i.schemaSlice); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Make the "items" keyword unmarshal successfully if its value is a valid
schema. Before it would only unmarshal it its value was a list of
schemas (both are valid values for "items").
